### PR TITLE
Read run.yaml's wall time as seconds, not millis

### DIFF
--- a/lib/util/epochs/index.js
+++ b/lib/util/epochs/index.js
@@ -68,7 +68,7 @@ module.exports = {
     try {
         var exp = yaml.safeLoad(fs.readFileSync(runFile))
         desc = exp.desc
-        wall = moment.duration(exp.wall)
+        wall = moment.duration({ seconds: exp.wall })
     } catch (e) { }
 
     const failDir = dirs.results(epoch, '.fail')


### PR DESCRIPTION
* `moment.duration()` uses millis by default, but run.yaml has its
  wall output in seconds, causing dimebox to wrongly think some
  running jobs have failed