### PR TITLE
Support for raw headers and runFlags in jobs. Closes #37

### DIFF
--- a/examples/raw.yml
+++ b/examples/raw.yml
@@ -1,0 +1,11 @@
+name: raw-flags
+desc: Showing use cases for raw headers and runFlags
+
+p: [1024]
+
+raw:
+  headers: ['-k', '--myheader ${p*5}']
+  runFlags: ["-S ${Math.log(p)*depth}", "-P l"]
+
+cmds:
+  myexe: ./myexe

--- a/lib/generate/jobs.js
+++ b/lib/generate/jobs.js
@@ -3,6 +3,7 @@
 let _   = require('lodash'),
     log = require('loglevel'),
     fse = require('node-fs-extra'),
+    dot = require('dot'),
     dirs = require('../util/dirs'),
     yaml    = require('js-yaml')
 
@@ -129,6 +130,17 @@ function nameOf(name, opt, weakargs) {
   return _.map(jobNameArgs, _.snakeCase).join('-')
 }
 
+/**
+ * Evaluate a user-provided expression in raw.headers or raw.runFlags.
+ *
+ * For example, if the user passes '--S ${p*2}' as a raw flag, we would
+ * like to emit '--S 4' if p=2.
+ */
+function evaluateExpression(expr, p, depth) {
+  let template = dot.template(expr, {interpolate: /\$\{([\s\S]+?)\}/g, varname: 'p,depth'});
+  return template(p, depth);
+}
+
 function generateJob(template, exp, epoch, opt) {
   const optargs = exp.optargs || []
   const p = opt[opt.length-2]
@@ -140,15 +152,23 @@ function generateJob(template, exp, epoch, opt) {
   // Evaluate raw headers
   let rawHeaders = []
   if (_.has(exp, 'raw.headers')) {
-    //rawHeaders = _.map(exp.raw.headers, eval)
-    rawHeaders = exp.raw.headers
+    try {
+      rawHeaders = _.map(exp.raw.headers, h => evaluateExpression(h, p, depth))
+    } catch (e) {
+      log.error(`Error evaluating raw.headers -- ${e}`)
+      process.exit(1);
+    }
   }
 
   // Evaluate raw runFlags
   let runFlags = []
   if (_.has(exp, 'raw.runFlags')) {
-    //rawHeaders = _.map(exp.raw.headers, eval)
-    runFlags = exp.raw.runFlags
+    try {
+      runFlags = _.map(exp.raw.runFlags, f => evaluateExpression(f, p, depth))
+    } catch (e) {
+      log.error(`Error evaluating raw.runFlags -- ${e}`)
+      process.exit(1);
+    }
   }
 
   // Pull in enviroment variables from config

--- a/lib/generate/jobs.js
+++ b/lib/generate/jobs.js
@@ -137,6 +137,20 @@ function generateJob(template, exp, epoch, opt) {
 
   const width = p*depth;
 
+  // Evaluate raw headers
+  let rawHeaders = []
+  if (_.has(exp, 'raw.headers')) {
+    //rawHeaders = _.map(exp.raw.headers, eval)
+    rawHeaders = exp.raw.headers
+  }
+
+  // Evaluate raw runFlags
+  let runFlags = []
+  if (_.has(exp, 'raw.runFlags')) {
+    //rawHeaders = _.map(exp.raw.headers, eval)
+    runFlags = exp.raw.runFlags
+  }
+
   // Pull in enviroment variables from config
   let exports = '';
   for (var key in exp.env) {
@@ -228,7 +242,8 @@ function generateJob(template, exp, epoch, opt) {
     epoch: epoch, 
     cmd: cmd,
     q: q,
-    cwd: cwd
+    cwd: cwd,
+    rawHeaders, runFlags
   })
 
   const filename = dirs.jobs(epoch, `${jobName}.job`)

--- a/lib/machines/edison.js
+++ b/lib/machines/edison.js
@@ -1,15 +1,19 @@
-const tmpl = (spec) => `#!/bin/bash -l
+const tmpl = (spec) => {
+  const headers = spec.rawHeaders.map(header => `#SBATCH ${header}`)
+  return `#!/bin/bash -l
 #SBATCH -p ${spec.q}
 #SBATCH -N ${Math.ceil(spec.p / 24)}
 #SBATCH -t ${spec.wall}
 #SBATCH -D ${spec.cwd}
 #SBATCH -e experiments/results/${spec.epoch}/stderr/${spec.name}.err
 #SBATCH -o experiments/results/${spec.epoch}/stdout/${spec.name}.out
+${headers}
 
-MPIRUN="srun -n ${spec.p} --ntasks-per-node=24"
+MPIRUN="srun -n ${spec.p} --ntasks-per-node=24 ${spec.runFlags}"
 
 ${spec.cmd}
 `
+}
 
 module.exports = {
   template: tmpl,

--- a/lib/machines/edison.js
+++ b/lib/machines/edison.js
@@ -1,5 +1,5 @@
 const tmpl = (spec) => {
-  const headers = spec.rawHeaders.map(header => `#SBATCH ${header}`)
+  const headers = spec.rawHeaders.map(header => `#SBATCH ${header}`).join('\n')
   return `#!/bin/bash -l
 #SBATCH -p ${spec.q}
 #SBATCH -N ${Math.ceil(spec.p / 24)}
@@ -9,7 +9,7 @@ const tmpl = (spec) => {
 #SBATCH -o experiments/results/${spec.epoch}/stdout/${spec.name}.out
 ${headers}
 
-MPIRUN="srun -n ${spec.p} --ntasks-per-node=24 ${spec.runFlags}"
+MPIRUN="srun -n ${spec.p} --ntasks-per-node=24 ${spec.runFlags.join(' ')}"
 
 ${spec.cmd}
 `

--- a/lib/machines/local.js
+++ b/lib/machines/local.js
@@ -1,5 +1,5 @@
 const tmpl = (spec) => `
-MPIRUN="mpirun -n ${spec.p}"
+MPIRUN="mpirun -n ${spec.p} ${spec.runFlags}"
 
 ${spec.cmd}`
 

--- a/lib/machines/rain.js
+++ b/lib/machines/rain.js
@@ -1,14 +1,17 @@
-const tmpl = (spec) => `
-#PBS -l mppwidth=${spec.width}
+const tmpl = (spec) => {
+  const headers = spec.rawHeaders.map(header => `#PBS ${header}`)
+  return `#PBS -l mppwidth=${spec.width}
 #PBS -l walltime=${spec.wall}
 #PBS -N ${spec.name}
 #PBS -e experiments/results/${spec.epoch}/stderr/${spec.name}.$PBS_JOBID.err
 #PBS -o experiments/results/${spec.epoch}/stdout/${spec.name}.$PBS_JOBID.out
 #PBS -V
+${headers}
 
-MPIRUN="aprun -n ${spec.p} -d ${spec.depth}"
+MPIRUN="aprun -n ${spec.p} -d ${spec.depth} ${spec.runFlags}"
 
 ${spec.cmd}`
+}
 
 module.exports = {
   template: tmpl,

--- a/lib/machines/rain.js
+++ b/lib/machines/rain.js
@@ -1,5 +1,5 @@
 const tmpl = (spec) => {
-  const headers = spec.rawHeaders.map(header => `#PBS ${header}`)
+  const headers = spec.rawHeaders.map(header => `#PBS ${header}`).join('\n')
   return `#PBS -l mppwidth=${spec.width}
 #PBS -l walltime=${spec.wall}
 #PBS -N ${spec.name}
@@ -8,7 +8,7 @@ const tmpl = (spec) => {
 #PBS -V
 ${headers}
 
-MPIRUN="aprun -n ${spec.p} -d ${spec.depth} ${spec.runFlags}"
+MPIRUN="aprun -n ${spec.p} -d ${spec.depth} ${spec.runFlags.join(' ')}"
 
 ${spec.cmd}`
 }

--- a/lib/machines/vulcan.js
+++ b/lib/machines/vulcan.js
@@ -1,5 +1,5 @@
 const tmpl = (spec) => {
-  const headers = spec.rawHeaders.map(header => `#MSUB ${header}`)
+  const headers = spec.rawHeaders.map(header => `#MSUB ${header}`).join('\n')
   return `#!/bin/bash
 #MSUB -l nodes=${Math.ceil(spec.p / 16)}
 #MSUB -l walltime=${spec.wall}
@@ -10,7 +10,7 @@ const tmpl = (spec) => {
 #MSUB -o experiments/results/${spec.epoch}/stdout/${spec.name}.%j.out
 ${headers}
 
-MPIRUN="srun -n ${spec.p} --ntasks-per-node=16 ${spec.runFlags}"
+MPIRUN="srun -n ${spec.p} --ntasks-per-node=16 ${spec.runFlags.join(' ')}"
 
 ${spec.cmd}
 `

--- a/lib/machines/vulcan.js
+++ b/lib/machines/vulcan.js
@@ -1,4 +1,6 @@
-const tmpl = (spec) => `#!/bin/bash
+const tmpl = (spec) => {
+  const headers = spec.rawHeaders.map(header => `#MSUB ${header}`)
+  return `#!/bin/bash
 #MSUB -l nodes=${Math.ceil(spec.p / 16)}
 #MSUB -l walltime=${spec.wall}
 #MSUB -q ${spec.q}
@@ -6,11 +8,13 @@ const tmpl = (spec) => `#!/bin/bash
 #MSUB -d ${spec.cwd}
 #MSUB -e experiments/results/${spec.epoch}/stderr/${spec.name}.%j.err
 #MSUB -o experiments/results/${spec.epoch}/stdout/${spec.name}.%j.out
+${headers}
 
-MPIRUN="srun -n ${spec.p} --ntasks-per-node=16"
+MPIRUN="srun -n ${spec.p} --ntasks-per-node=16 ${spec.runFlags}"
 
 ${spec.cmd}
 `
+}
 
 module.exports = {
   template: tmpl,

--- a/lib/util/expfile.js
+++ b/lib/util/expfile.js
@@ -7,7 +7,7 @@ const fs    = require('fs'),
       _     = require('underscore')
 
 function checkUnknownFields(exp) {
-  const whitelist = ['name', 'desc', 'p', 'cmds', 'optargs', 'weakargs', 'env', 'q', 'workspace', 'trials', 'wall', 'epilogue', 'depth', 'depthvar']
+  const whitelist = ['name', 'desc', 'p', 'cmds', 'optargs', 'weakargs', 'env', 'q', 'workspace', 'trials', 'wall', 'epilogue', 'depth', 'depthvar', 'raw']
 
   for (const key of _.keys(exp)) {
     if (!_.contains(whitelist, key))
@@ -71,6 +71,23 @@ function validateExp(exp) {
 
   // wall
   if (!check.string(exp.wall)) throw Error("wall must be a string")
+
+  // raw flags
+  if (exp.raw) {
+    if (!check.object(exp.raw)) throw Error("raw field must be an object")
+
+    if (!exp.raw.headers && !exp.raw.runFlags) throw Error("raw field must have a headers or runFlags subfield")
+
+    // raw headers
+    if (exp.raw.headers) {
+      if (!check.array.of.string(exp.raw.headers)) throw Error("Raw headers must be an array of strings")
+    }
+
+    // runFlags
+    if (exp.raw.runFlags) {
+      if (!check.array.of.string(exp.raw.runFlags)) throw Error("Raw runFlags must be an array of strings")
+    }
+  }
 }
 
 function loadExpfile(filename) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chalk": "^1.1.1",
     "check-types": "^6.0.0",
     "cli-table": "^0.3.1",
+    "dot": "^1.0.3",
     "js-yaml": "^3.5.3",
     "lodash": "^4.13.1",
     "loglevel": "^1.4.0",

--- a/test/generate.js
+++ b/test/generate.js
@@ -72,28 +72,17 @@ describe('simple generateJobs', function(){
 })
 
 
-describe('vulcan', function(){
-  const vulcanTemplate = require('../lib/machines/vulcan').template
+describe('actual machines', function(){
+  const machines = ['vulcan', 'rain', 'edison']
 
   it('generated something', function(){
-     const js = jobs.generateJobs(vulcanTemplate, exp, epoch)
-     js.map(j => {
-       const job = j.contents
-       expect(job).to.be.not.empty
-     });
-  });
-
-})
-
-
-describe('rain', function(){
-  const vulcanTemplate = require('../lib/machines/rain').template
-
-  it('generated something', function(){
-     const js = jobs.generateJobs(vulcanTemplate, exp, epoch)
-     js.map(j => {
-       const job = j.contents
-       expect(job).to.be.not.empty
+     machines.map(m => {
+      const machineTemplate = require('../lib/machines/' + m).template
+       const js = jobs.generateJobs(machineTemplate, exp, epoch)
+       js.map(j => {
+         const job = j.contents
+         expect(job).to.be.not.empty
+       });
      });
   });
 


### PR DESCRIPTION
This PR adds support for raw headers and runFlags. An example:

```yml
raw:
  headers: ['-l mppnppn=${p>12 ? 12 : p}']
```
 