### PR TITLE
Dump parser params when necessary, closes #51

### DIFF
--- a/lib/parse/dump.js
+++ b/lib/parse/dump.js
@@ -3,7 +3,8 @@
 const fs = require('node-fs-extra'),
       log = require('loglevel'),
       crypto = require('crypto'),
-      dirs = require('../util/dirs')
+      dirs = require('../util/dirs'),
+      _ = require('lodash')
 
 // Dump parsed experiment to a file
 module.exports = function(opt) {
@@ -11,6 +12,7 @@ module.exports = function(opt) {
   const epoch = opt.epoch
   const parserName = opt.parserName
   const parser = opt.parser
+  const parserArgs = opt.parserArgs
 
   const parserHash =  crypto.createHash('sha1').update(parser).digest('hex')
 
@@ -25,6 +27,9 @@ module.exports = function(opt) {
     },
     failed: parsed.failed
   }
+
+  if(parserArgs && parserArgs.length > 0)
+    _.extend(results.parser, { args: parserArgs })
 
   const fname = dirs.results(epoch, '.parsed', 'results.json')
   fs.outputJSONSync(fname, results, {spaces:5})

--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -49,6 +49,7 @@ module.exports = function(opt) {
     epoch,
     parserName: parser,
     parser: parserFn.toString(),
+    parserArgs: !(parserFn instanceof Function) ? params : null,
     parsed: results
   })
 

--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -44,12 +44,14 @@ module.exports = function(opt) {
     process.exit(1)
   }
 
+  const usesParams = !(parserFn instanceof Function) && (parserFn.onInit instanceof Function)
+
   // Dump parsed results to file
   dump({
     epoch,
     parserName: parser,
     parser: parserFn.toString(),
-    parserArgs: !(parserFn instanceof Function) ? params : null,
+    parserArgs: usesParams ? params : null,
     parsed: results
   })
 


### PR DESCRIPTION
This does the absolute minimum to only dump parser arguments when the parser is an object with an `onInit()` method (since anything not that can't use them) and they aren't empty.