### PR TITLE
Add support for prologue, closes #12

### DIFF
--- a/lib/generate/jobs.js
+++ b/lib/generate/jobs.js
@@ -207,6 +207,11 @@ function generateJob(template, exp, expObjs, combinedKeys, epoch, opt) {
   // Change directory to cwd or an isolated workspace if specified
   cmd += `\ncd ${workspace}\n`
 
+  // If there is an prologue, add it to command
+  if (exp.prologue) {
+    cmd += `\n${exp.prologue}`
+  }
+
   // Set up trial loop
   const numTrials = exp.trials || 1
   cmd += `\nfor DIMEBOX_TRIAL_ID in \`seq 0 ${numTrials-1}\`\ndo`

--- a/lib/util/expfile.js
+++ b/lib/util/expfile.js
@@ -8,7 +8,7 @@ const fs    = require('fs'),
       _     = require('lodash')
 
 function checkUnknownFields(exp) {
-  const whitelist = ['name', 'desc', 'p', 'cmds', 'optargs', 'pairargs', 'weakargs', 'env', 'q', 'workspace', 'trials', 'wall', 'epilogue', 'depth', 'depthvar', 'raw']
+  const whitelist = ['name', 'desc', 'p', 'cmds', 'optargs', 'pairargs', 'weakargs', 'env', 'q', 'workspace', 'trials', 'wall', 'prologue', 'epilogue', 'depth', 'depthvar', 'raw']
 
   for (const key of _.keys(exp)) {
     if (!_.includes(whitelist, key))

--- a/test/expfile.js
+++ b/test/expfile.js
@@ -18,7 +18,7 @@ describe('missing required fields', function(){
 
 describe('allowed fields', function(){
   it('field in whitelist', function(){
-    const exp = _.assign({epilogue: "bar"}, base)
+    const exp = _.assign({epilogue: "bar", prologue: "foo"}, base)
      expect(() => validate(exp)).to.not.throw(Error)
   });
 


### PR DESCRIPTION
This adds a prologue to execute just before the trial loop starts.

Strangely enough, `prologue` is in the docs already even though it didn't exist yet.