### PR TITLE
Allow parsers to return arrays of {key,value} objects

### DIFF
--- a/lib/parse/parse-file.js
+++ b/lib/parse/parse-file.js
@@ -102,13 +102,20 @@ function parse(file, parser, tag) {
       parserThrew = true
     }
 
-    if(parsedLine)
     // If the parser found something useful and it is either the same tag or doesn't have a tag
     if (parsedLine && (!parsedLine.tag || parsedLine.tag == tag)) {
 
       // This is an observation
       if (parsedLine.kvs instanceof Array)
         obs.push(parsedLine.kvs)
+
+      // This is an array of global key-values for this result
+      else if (parsedLine instanceof Array) {
+        // Push arrays of key,value for those with the right tag
+        const matching = parsedLine.filter(e => !e.tag || e.tag == tag)
+        Array.prototype.push.apply(kvs, matching.map(e => [e.key, e.value]))
+      }
+
       // This is a global key-value for this result
       else
         kvs.push([parsedLine.key, parsedLine.value])


### PR DESCRIPTION
Currently parsers can only return either an observation or one key-value pair per line. So, if for example, your program has tabular output and you can't parse multiple columns for a row (e.g. for `gcc -ftime-report`) unless you use the same keys for each row and put it as an observation. 

This PR has the minimal amount of code I used to get a parser for `gcc -ftime-report` output working.