### PR TITLE
Replace some instances of map() with forEach()

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -58,7 +58,7 @@ module.exports = function(opt) {
   // Print header and rows
   if(results) {
     log.info(results.header.join('\t'))
-    results.rows.map(row => {
+    results.rows.forEach(row => {
       log.info(row.join('\t'))
     })
   } else {

--- a/lib/parse/parse-epoch.js
+++ b/lib/parse/parse-epoch.js
@@ -75,7 +75,7 @@ module.exports = function (opt) {
   // Print information about failed files
   const emptyResults = _.filter(parsedResults, result => result.observations.length == 0)
   if (emptyResults.length > 0) {
-    emptyResults.map(f => {
+    emptyResults.forEach(f => {
       log.warn(warn, "Result has no information:", f.file)
     })
   }
@@ -101,7 +101,7 @@ module.exports = function (opt) {
   const rowsAsMaps = _.chain(observationsAsRows).map(result => {
     let row = result.kvs
     let m = new Map()
-    row.map(kv => {
+    row.forEach(kv => {
       if (m.has(kv[0])) {
         log.warn(warn, `file contains same key '${kv[0]}' twice:`)
         log.warn(result.file)

--- a/lib/parse/parse-file.js
+++ b/lib/parse/parse-file.js
@@ -92,7 +92,7 @@ function parse(file, parser, tag) {
   let parserThrew = false
 
   // Feed each line to parser
-  contents.toString().split('\n').map(line => {
+  contents.toString().split('\n').forEach(line => {
     // Call parser to receive array of [key, value]
     try {
       var parsedLine = parser(line)

--- a/lib/util/epochs/index.js
+++ b/lib/util/epochs/index.js
@@ -12,7 +12,7 @@ const fs      = require('fs'),
 // Insert all of the results from the input array to the output array
 // and add information about state and parameters.
 function contributeAll(output, input, state) {
-  input.map(r => {
+  input.forEach(r => {
     output.push({
       state: state,
       modified: r.modified,

--- a/lib/util/validate.js
+++ b/lib/util/validate.js
@@ -6,7 +6,7 @@ const fs  = require('fs'),
 
 module.exports = function() {
   const subdirs = ['experiments', 'experiments/jobs', 'experiments/results']
-  subdirs.map(dir => {
+  subdirs.forEach(dir => {
     if (!fs.existsSync(dirs.build(dir))) {
       log.error(`Error: directory '${dir}' does not exist. Perhaps perform dimebox init?`)
       process.exit(1)

--- a/lib/watch/watch.js
+++ b/lib/watch/watch.js
@@ -15,7 +15,7 @@ const fs = require('fs'),
 // Insert all of the results from the input array to the output array
 // and add information about state and parameters.
 function contributeAll(output, input, epoch, state) {
-  input.map(r => {
+  input.forEach(r => {
     output.push({
       state: state,
       modified: r.modified,

--- a/test/generate.js
+++ b/test/generate.js
@@ -39,14 +39,14 @@ describe('trivial generateJobs', function(){
      const j = jobs.generateJobs(tmpl, exp, expObjs, epoch)
      expect(j).to.be.a('array');
      
-     j.map(job => {
+     j.forEach(job => {
        expect(job).to.have.all.keys('filename', 'contents')
      })
   });
 
   it('jobs have filenames and are not empty', function(){
      const j = jobs.generateJobs(tmpl, exp, expObjs, epoch)
-     j.map(job => {
+     j.forEach(job => {
        expect(job.filename).to.have.length.least(1)
        expect(job.contents).to.have.length.least(1)
      })
@@ -54,7 +54,7 @@ describe('trivial generateJobs', function(){
 
   it('optargs with spaces do not have spaces in filename', function(){
      const j = jobs.generateJobs(tmpl, exp, expObjs, epoch)
-     j.map(job => {
+     j.forEach(job => {
        expect(job.filename).to.not.contain(" ")
      })
   });
@@ -63,7 +63,7 @@ describe('trivial generateJobs', function(){
 describe('simple generateJobs', function(){
   it('p is same as the filename and exp', function(){
      const js = structuredJobs(jobs.generateJobs(tmpl, exp, expObjs, epoch))
-     js.map(j => {
+     js.forEach(j => {
        const job = j.contents
        const filename = j.filename.split('-')
        const pFromFile = Number(filename[filename.length-2].split('.')[0])
@@ -74,7 +74,7 @@ describe('simple generateJobs', function(){
 
   it('depth is same as the filename and exp', function(){
      const js = structuredJobs(jobs.generateJobs(tmpl, exp, expObjs, epoch))
-     js.map(j => {
+     js.forEach(j => {
        const job = j.contents
        const filename = j.filename.split('-')
        const dFromFile = Number(filename[filename.length-1].split('.')[0])
@@ -89,10 +89,10 @@ describe('actual machines', function(){
   const machines = ['vulcan', 'rain', 'edison']
 
   it('generated something', function(){
-     machines.map(m => {
+     machines.forEach(m => {
       const machineTemplate = require('../lib/machines/' + m).template
        const js = jobs.generateJobs(machineTemplate, exp, expObjs, epoch)
-       js.map(j => {
+       js.forEach(j => {
          const job = j.contents
          expect(job).to.be.not.empty
        });


### PR DESCRIPTION
Changed some instances of `.map()` to `.forEach()` where the return value was not needed.